### PR TITLE
[FIX] website_quote: fix Sign & Confirm

### DIFF
--- a/addons/website_quote/controllers/main.py
+++ b/addons/website_quote/controllers/main.py
@@ -77,7 +77,7 @@ class sale_quote(http.Controller):
                     context=render_ctx)
         return request.website.render('website_quote.so_quotation', values)
 
-    @http.route(['/quote/accept/<int:order_id>'], type='http', auth="public", website=True, methods=['POST'])
+    @http.route(['/quote/accept'], type='json', auth="public", website=True)
     def accept(self, order_id, token=None, signer=None, sign=None, **post):
         order_obj = request.registry.get('sale.order')
         order = order_obj.browse(request.cr, SUPERUSER_ID, order_id)

--- a/addons/website_quote/static/src/js/website_quotation.js
+++ b/addons/website_quote/static/src/js/website_quotation.js
@@ -64,7 +64,7 @@ if(!$('.o_website_quote').length) {
             var self = this;
             var href = self.$el.find('form').attr("action");
             var action = href.match(/quote\/([a-z]+)/);
-            var order_id = href.match(/quote\/[a-z]+\/([0-9]+)/);
+            var order_id = href.match(/order_id=(.*)&/);
             var token = href.match(/token=(.*)/);
             if (token){
                 token = token[1];

--- a/addons/website_quote/views/website_quotation.xml
+++ b/addons/website_quote/views/website_quotation.xml
@@ -229,7 +229,7 @@
                       <!-- modal relative to the actions Accept/Reject/Cancel -->
                       <div class="modal fade" id="modalaccept" role="dialog" aria-hidden="true">
                         <div class="modal-dialog" t-if="not quotation.require_payment and not need_payment">
-                           <form id="accept" method="POST" t-attf-action="/quote/accept/#{quotation.id}/?token=#{quotation.access_token}" class="js_accept_json modal-content js_website_submit_form">
+                           <form id="accept" method="POST" t-attf-action="/quote/accept?order_id=#{quotation.id}&amp;token=#{quotation.access_token}" class="js_accept_json modal-content js_website_submit_form">
                             <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                             <div class="modal-header">
                               <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&amp;times;</button>


### PR DESCRIPTION
Commit 7636b51 modifies the route from JSON to HTTP by mistake. Indeed,
the route /quote/accept is called from an ajax.jsonRpc request, not from
the `method="POST" t-attf-action="/quote/accept` which can be found in
website_quotation.xml.

The t-attf-action is actually only used to recover the order_id and the
token in website_quotation.js.

opw-652874
Closes #9227
Fixes #9226